### PR TITLE
Remove useless var assignment

### DIFF
--- a/lib/shift_generator.rb
+++ b/lib/shift_generator.rb
@@ -16,11 +16,10 @@ class ShiftGenerator
 
   def assign_keys
     @key = random_nums if key.nil?
-    a_key = @key[0..1].to_i
-    b_key = @key[1..2].to_i
-    c_key = @key[2..3].to_i
-    d_key = @key[3..4].to_i
-    assigned_keys = a_key, b_key, c_key, d_key
+    [a_key = @key[0..1].to_i,
+    b_key = @key[1..2].to_i,
+    c_key = @key[2..3].to_i,
+    d_key = @key[3..4].to_i]
   end
 
   def transmission_date(_date = nil)
@@ -31,11 +30,10 @@ class ShiftGenerator
   def assign_offsets
     transmission_date
     new_date = (@date.to_i**2).to_s
-    a_offset = new_date[-4].to_i
-    b_offset = new_date[-3].to_i
-    c_offset = new_date[-2].to_i
-    d_offset = new_date[-1].to_i
-    assigned_offsets = a_offset, b_offset, c_offset, d_offset
+    [a_offset = new_date[-4].to_i,
+    b_offset = new_date[-3].to_i,
+    c_offset = new_date[-2].to_i,
+    d_offset = new_date[-1].to_i]
   end
 
   def all_shifts


### PR DESCRIPTION
### Change Log:

What I did:
- Removed useless var assignment for assign_keys and assign_offsets method in shift_generator